### PR TITLE
docs(themes): add DB settings for translatable config

### DIFF
--- a/docs/developpers/themes/config.md
+++ b/docs/developpers/themes/config.md
@@ -37,3 +37,7 @@ To retrieve the configuration in your theme, you can use the `theme_config` meth
 ```php
 {{ theme_config('config_1') }}
 ```
+
+:::tip Translatable Configuration
+If you need some configuration fields to support multiple languages, you can store them in the database instead of `config.json`. See [Database Settings](./db-settings.md) for details.
+:::

--- a/docs/developpers/themes/create-theme.md
+++ b/docs/developpers/themes/create-theme.md
@@ -21,7 +21,8 @@ resources/themes/
     ├── config/
     │   └── config.json
     │   └── config.blade.php
-    │   └── rules.blade.php
+    │   └── rules.php
+    │   └── db_settings.php
     ├── lang/
     │   └── fr/
     │       └── messages.php

--- a/docs/developpers/themes/db-settings.md
+++ b/docs/developpers/themes/db-settings.md
@@ -1,0 +1,150 @@
+---
+sidebar_position: 5
+translated: true
+---
+# Database Settings
+
+By default, theme configuration is stored in a `config.json` file. This works well for non-translatable settings like colors, layout options, or feature toggles. However, some configuration fields may need to support multiple languages (e.g., a hero title, a subtitle, or footer text).
+
+Database settings allow themes to store specific configuration fields in the database via the `Setting` model, enabling full translation support through the existing `Translatable` trait and the `translated_setting()` helper.
+
+## How It Works
+
+When a theme saves its configuration, the system now splits the data into two storage backends:
+
+1. **Database** (`settings` table): Fields listed in `$dbSettings` are saved via `Setting::updateSettings()` and support per-locale translations.
+2. **JSON file** (`config.json`): All remaining fields are saved to the file as before.
+
+```
+Save theme configuration
+        |
+        v
++------------------+
+| Validate fields  |
++------------------+
+        |
+        v
++----------------------------+
+| Is the key in dbSettings?  |
++-------+--------------------+
+   Yes  |          No
+   v    |          v
++-------+--+  +---+----------+
+| settings |  | config.json  |
+| table    |  | file         |
++----------+  +--------------+
+```
+
+## Configuration File
+
+To enable database settings, create a `db_settings.php` file in your theme's `config/` directory:
+
+```
+resources/themes/your_theme/
+├── config/
+│   ├── config.blade.php     # Configuration form
+│   ├── config.json          # Non-translatable defaults
+│   ├── rules.php            # Validation rules
+│   └── db_settings.php      # Keys to store in database
+```
+
+The file returns an array of field names that should be stored in the database:
+
+```php
+<?php
+
+return [
+    'hero_title',
+    'hero_subtitle',
+    'footer_text',
+];
+```
+
+These keys must match the field names used in your `config.blade.php` form and `rules.php` validation file.
+
+## Accessing Values
+
+Use the appropriate helper depending on where the value is stored:
+
+```php
+// Non-translatable values (from config.json)
+{{ theme_config('primary_color') }}
+
+// Translatable values (from database)
+{{ translated_setting('hero_title') }}
+```
+
+:::tip When to use which helper
+- `theme_config()` - For values that are the same across all languages (colors, booleans, numeric values, layout options).
+- `translated_setting()` - For values that need to change per locale (titles, descriptions, text content).
+:::
+
+## Complete Example
+
+### 1. Define translatable keys
+
+**`config/db_settings.php`**
+```php
+<?php
+
+return [
+    'hero_title',
+    'hero_subtitle',
+];
+```
+
+### 2. Create the configuration form
+
+**`config/config.blade.php`**
+```blade
+{{-- Translatable fields (stored in database) --}}
+@include('shared.text', [
+    'name' => 'hero_title',
+    'label' => 'Hero Title',
+    'value' => translated_setting('hero_title'),
+])
+
+@include('shared.text', [
+    'name' => 'hero_subtitle',
+    'label' => 'Hero Subtitle',
+    'value' => translated_setting('hero_subtitle'),
+])
+
+{{-- Non-translatable field (stored in config.json) --}}
+@include('shared.text', [
+    'name' => 'primary_color',
+    'label' => 'Primary Color',
+    'value' => theme_config('primary_color', '#2c46ba'),
+])
+```
+
+### 3. Add validation rules
+
+**`config/rules.php`**
+```php
+<?php
+
+return [
+    'hero_title' => 'required|string|max:255',
+    'hero_subtitle' => 'required|string|max:500',
+    'primary_color' => 'required|string|max:7',
+];
+```
+
+### 4. Use values in your views
+
+**`views/layouts/front.blade.php`**
+```blade
+<section class="hero">
+    <h1>{{ translated_setting('hero_title') }}</h1>
+    <p>{{ translated_setting('hero_subtitle') }}</p>
+</section>
+```
+
+## Adding Translations
+
+Once a field is stored in the database, translations can be managed through the ClientXCMS admin panel using the built-in translation system. Each `Setting` entry uses the `Translatable` trait, allowing per-locale values to be defined.
+
+:::info
+Fields stored in the database will appear in the translation management interface automatically. No additional configuration is required to enable translation for these fields.
+:::

--- a/docs/developpers/themes/forms.md
+++ b/docs/developpers/themes/forms.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 translated: true
 ---
 # Forms

--- a/docs/developpers/themes/functions-settings.md
+++ b/docs/developpers/themes/functions-settings.md
@@ -35,6 +35,7 @@ This page lists the functions and setting keys usable for themes.
 | `{{ is_route($route) }}`                                     | Returns true if the route is the current route   |
 | `{{ ctx_version() }}`                                        | Returns the CLIENTXCMS version                   |
 | `{{ theme_config($key, $default = null) }}`                  | Returns the theme configuration                  |
+| `{{ translated_setting($key, $default = null) }}`            | Returns a translatable setting value from the database |
 
 ## Settings
 

--- a/docs/developpers/themes/sections.md
+++ b/docs/developpers/themes/sections.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 translated: true
 ---
 # Sections

--- a/docs/settings/core/locales.md
+++ b/docs/settings/core/locales.md
@@ -109,19 +109,20 @@ CLIENTXCMS automatically detects:
 
 When a language is activated, the following elements are translated:
 
-✅ **User interface**: All menus, buttons, and messages
-✅ **Automated emails**: Notifications, invoices, confirmations
-✅ **System messages**: Errors, confirmations, alerts
-✅ **Static content**: Legal pages, terms and conditions
+- ✅ **User interface**: All menus, buttons, and messages
+- ✅ **Automated emails**: Notifications, invoices, confirmations
+- ✅ **System messages**: Errors, confirmations, alerts
+- ✅ **Static content**: Legal pages, terms and conditions
+- ✅ **Theme configuration**: Translatable fields defined by the theme (titles, descriptions, text content) — if the active theme supports [database settings](/developpers/themes/db-settings)
 
 ### Elements Requiring Manual Translation
 
 Some content requires manual translation:
 
-📝 **Product descriptions**: Via the product management interface
-📝 **Custom pages**: Specifically created content
-📝 **Announcements and news**: Marketing communications
-📝 **SEO metadata**: Titles and descriptions for search engines
+- 📝 **Product descriptions**: Via the product management interface
+- 📝 **Custom pages**: Specifically created content
+- 📝 **Announcements and news**: Marketing communications
+- 📝 **SEO metadata**: Titles and descriptions for search engines
 
 ## Translation Customization
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/config.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/config.md
@@ -36,3 +36,7 @@ Pour récupérer la configuration dans votre thème, vous pouvez utiliser la mé
 ```php
 {{ theme_config('config_1') }}
 ```
+
+:::tip Configuration traduisible
+Si vous avez besoin que certains champs de configuration supportent plusieurs langues, vous pouvez les stocker en base de données au lieu de `config.json`. Consultez [Configuration en base de données](./db-settings.md) pour plus de détails.
+:::

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/create-theme.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/create-theme.md
@@ -20,7 +20,8 @@ resources/themes/
     ├── config/
     │   └── config.json
     │   └── config.blade.php
-    │   └── rules.blade.php
+    │   └── rules.php
+    │   └── db_settings.php
     ├── lang/
     │   └── fr/
     │       └── messages.php

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/db-settings.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/db-settings.md
@@ -1,0 +1,150 @@
+---
+sidebar_position: 5
+---
+# Configuration en base de données
+
+Par défaut, la configuration d'un thème est stockée dans un fichier `config.json`. Cela fonctionne bien pour les paramètres non traduisibles comme les couleurs, les options de mise en page ou les toggles de fonctionnalités. Cependant, certains champs de configuration peuvent nécessiter un support multilingue (par exemple un titre de hero, un sous-titre ou un texte de pied de page).
+
+Les paramètres en base de données permettent aux thèmes de stocker des champs de configuration spécifiques dans la base de données via le modèle `Setting`, offrant un support complet de traduction grâce au trait `Translatable` et au helper `translated_setting()`.
+
+## Fonctionnement
+
+Lorsqu'un thème sauvegarde sa configuration, le système sépare les données en deux backends de stockage :
+
+1. **Base de données** (table `settings`) : Les champs listés dans `$dbSettings` sont sauvegardés via `Setting::updateSettings()` et supportent les traductions par locale.
+2. **Fichier JSON** (`config.json`) : Tous les autres champs sont sauvegardés dans le fichier comme auparavant.
+
+```
+Sauvegarde de la configuration du thème
+        |
+        v
++---------------------+
+| Validation des      |
+| champs              |
++---------------------+
+        |
+        v
++-------------------------------+
+| La clé est dans dbSettings ?  |
++-------+-----------------------+
+   Oui  |          Non
+   v    |          v
++-------+--+  +---+----------+
+| table    |  | fichier      |
+| settings |  | config.json  |
++----------+  +--------------+
+```
+
+## Fichier de configuration
+
+Pour activer les paramètres en base de données, créez un fichier `db_settings.php` dans le dossier `config/` de votre thème :
+
+```
+resources/themes/votre_theme/
+├── config/
+│   ├── config.blade.php     # Formulaire de configuration
+│   ├── config.json          # Valeurs par défaut non traduisibles
+│   ├── rules.php            # Règles de validation
+│   └── db_settings.php      # Clés à stocker en base de données
+```
+
+Le fichier retourne un tableau de noms de champs qui doivent être stockés en base de données :
+
+```php
+<?php
+
+return [
+    'hero_title',
+    'hero_subtitle',
+    'footer_text',
+];
+```
+
+Ces clés doivent correspondre aux noms de champs utilisés dans votre formulaire `config.blade.php` et votre fichier de validation `rules.php`.
+
+## Accéder aux valeurs
+
+Utilisez le helper approprié en fonction de l'endroit où la valeur est stockée :
+
+```php
+// Valeurs non traduisibles (depuis config.json)
+{{ theme_config('primary_color') }}
+
+// Valeurs traduisibles (depuis la base de données)
+{{ translated_setting('hero_title') }}
+```
+
+:::tip Quel helper utiliser ?
+- `theme_config()` - Pour les valeurs identiques dans toutes les langues (couleurs, booléens, valeurs numériques, options de mise en page).
+- `translated_setting()` - Pour les valeurs qui doivent changer selon la locale (titres, descriptions, contenu textuel).
+:::
+
+## Exemple complet
+
+### 1. Définir les clés traduisibles
+
+**`config/db_settings.php`**
+```php
+<?php
+
+return [
+    'hero_title',
+    'hero_subtitle',
+];
+```
+
+### 2. Créer le formulaire de configuration
+
+**`config/config.blade.php`**
+```blade
+{{-- Champs traduisibles (stockés en base de données) --}}
+@include('shared.text', [
+    'name' => 'hero_title',
+    'label' => 'Titre du hero',
+    'value' => translated_setting('hero_title'),
+])
+
+@include('shared.text', [
+    'name' => 'hero_subtitle',
+    'label' => 'Sous-titre du hero',
+    'value' => translated_setting('hero_subtitle'),
+])
+
+{{-- Champ non traduisible (stocké dans config.json) --}}
+@include('shared.text', [
+    'name' => 'primary_color',
+    'label' => 'Couleur principale',
+    'value' => theme_config('primary_color', '#2c46ba'),
+])
+```
+
+### 3. Ajouter les règles de validation
+
+**`config/rules.php`**
+```php
+<?php
+
+return [
+    'hero_title' => 'required|string|max:255',
+    'hero_subtitle' => 'required|string|max:500',
+    'primary_color' => 'required|string|max:7',
+];
+```
+
+### 4. Utiliser les valeurs dans les vues
+
+**`views/layouts/front.blade.php`**
+```blade
+<section class="hero">
+    <h1>{{ translated_setting('hero_title') }}</h1>
+    <p>{{ translated_setting('hero_subtitle') }}</p>
+</section>
+```
+
+## Ajouter des traductions
+
+Une fois qu'un champ est stocké en base de données, les traductions peuvent être gérées via le panneau d'administration ClientXCMS grâce au système de traduction intégré. Chaque entrée `Setting` utilise le trait `Translatable`, permettant de définir des valeurs par locale.
+
+:::info
+Les champs stockés en base de données apparaissent automatiquement dans l'interface de gestion des traductions. Aucune configuration supplémentaire n'est nécessaire pour activer la traduction de ces champs.
+:::

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/forms.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/forms.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 # Formulaire
 Les formulaires sont des éléments essentiels pour interagir avec les utilisateurs et sont souvent utilisés pour collecter des informations. Les formulaires sont utilisés pour collecter des informations de l'utilisateur, telles que les coordonnées, les commentaires, les avis, etc. Les formulaires sont également utilisés pour collecter des informations de l'utilisateur, telles que l'inscription, le checkout etc.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/functions-settings.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/functions-settings.md
@@ -34,6 +34,7 @@ Cette page liste les fonctions et clés de paramètres utilisables pour les thè
 | `{{ is_route($route) }}`                                     | Retourne vrai si la route est la route actuelle  |
 | `{{ ctx_version() }}`                                        | Retourne la version de CLIENTXCMS                |
 | `{{ theme_config($key, $default = null) }}`                  | Retourne la configuration du thème               |
+| `{{ translated_setting($key, $default = null) }}`            | Retourne une valeur de paramètre traduisible depuis la base de données |
 
 ## Paramètres
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/sections.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developpers/themes/sections.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 # Sections
 Les sections sont des éléments de contenu qui peuvent être ajoutés à une page CLIENTXCMS. Elles sont pilotées par les thèmes et peuvent être personnalisées dans l'interface d'administration depuis la page section dans les paramètres de personalisation.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/settings/core/locales.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/settings/core/locales.md
@@ -108,19 +108,20 @@ CLIENTXCMS détecte automatiquement :
 
 Lorsqu'une langue est activée, les éléments suivants sont traduits :
 
-✅ **Interface utilisateur** : Tous les menus, boutons et messages
-✅ **E-mails automatiques** : Notifications, factures, confirmations
-✅ **Messages système** : Erreurs, confirmations, alertes
-✅ **Contenu statique** : Pages légales, conditions générales
+- ✅ **Interface utilisateur** : Tous les menus, boutons et messages
+- ✅ **E-mails automatiques** : Notifications, factures, confirmations
+- ✅ **Messages système** : Erreurs, confirmations, alertes
+- ✅ **Contenu statique** : Pages légales, conditions générales
+- ✅ **Configuration du thème** : Champs traduisibles définis par le thème (titres, descriptions, contenu textuel) — si le thème actif supporte les [paramètres en base de données](/fr/developpers/themes/db-settings)
 
 ### Éléments à traduire manuellement
 
 Certains contenus nécessitent une traduction manuelle :
 
-📝 **Descriptions de produits** : Via l'interface de gestion des produits
-📝 **Pages personnalisées** : Contenu créé spécifiquement
-📝 **Annonces et actualités** : Communications marketing
-📝 **Métadonnées SEO** : Titres et descriptions pour le référencement
+- 📝 **Descriptions de produits** : Via l'interface de gestion des produits
+- 📝 **Pages personnalisées** : Contenu créé spécifiquement
+- 📝 **Annonces et actualités** : Communications marketing
+- 📝 **Métadonnées SEO** : Titres et descriptions pour le référencement
 
 ## Personnalisation des traductions
 


### PR DESCRIPTION
## Summary

Documents the new theme database settings feature introduced in [ClientXCMS/ClientXCMS#20](https://github.com/ClientXCMS/ClientXCMS/pull/20).

- New dedicated page `developpers/themes/db-settings` (EN + FR)
- Updated theme structure in `create-theme` with `db_settings.php`
- Added `translated_setting()` to the functions reference table
- Added cross-reference tip in the config page
- Updated `locales` page to mention theme translatable fields
- Fixed markdown list rendering in locales page