### PR TITLE
blog: add multilingual documentation announcement

### DIFF
--- a/blog/2026-01-31-clientxcms-documentation-multilingual.md
+++ b/blog/2026-01-31-clientxcms-documentation-multilingual.md
@@ -1,0 +1,56 @@
+---
+title: CLIENTXCMS Documentation Now Available in French and English
+url: /blog/2026-01-31-clientxcms-documentation-multilingual
+authors: [martindev, alexandre]
+tags: [documentation, update, internationalization, accessibility, ai-workflow]
+translated: true
+---
+
+Hi everyone,
+We are happy to announce that the **CLIENTXCMS documentation is now fully available in both French and English**.
+
+This update is part of a broader effort to internationalize the project, with **English as the primary language** to encourage contributions from the global community.
+
+{/* TODO: add header image at /img/blog/clientxcms-documentation-multilingual/header.png */}
+
+<!-- truncate -->
+
+## Internationalization first
+
+We're making internationalization a priority for CLIENTXCMS. By adopting English as the primary language for both code and documentation, we aim to:
+
+- Lower the barrier for international contributors
+- Facilitate collaboration across different regions
+- Build a stronger, more diverse community around the project
+
+All documentation pages have been fully translated to ensure a consistent experience in both languages. You can switch between them using the **language selector at the top of the documentation**.
+
+## Moving towards AA accessibility
+
+We're progressively working to meet **WCAG 2.1 AA accessibility standards**. The CMS will undergo several major updates focused on:
+
+- Reducing the number of clicks needed to perform actions
+- Making the interface more intuitive
+- Improving overall usability for all users
+
+Accessibility isn't just a checkbox -- it's about making the product usable by everyone.
+
+## AI-powered workflows
+
+To address the reality of limited time and contributors, we've started implementing **AI-assisted workflows** into our development process.
+
+For this documentation update, the entire translation was completed in **under 30 minutes** using Claude Code Web. This kind of efficiency allows us to focus our energy where it matters most.
+
+We've also forked and adapted [BMAD](https://github.com/bmadcode/BMAD-METHOD) to fit our needs. All sources are available, and we encourage every contributor to use the workflow we've set up -- including the `bmad` folder and Claude commands. We will not be offering any agents other than Claude in our workflows, given its market share and its effectiveness for our needs.
+
+## Why this matters
+
+Providing multilingual documentation allows:
+
+- Better accessibility for international users
+- Easier onboarding for new teams
+- Improved understanding of features and workflows
+
+Don't forget that we encourage each and every one of you to contribute to the project, no matter how small the contribution!
+
+We hope this update improves your experience with CLIENTXCMS, and as always, feedback is welcome!

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -15,3 +15,9 @@ freezmod:
   title: Développeur - Conseiller retour à la communauté
   url: https://github.com/TomLeDev
   image_url: https://github.com/TomLeDev.png
+
+alexandre:
+  name: Alexandre
+  title: System & Network Administrator DevOps
+  url: https://github.com/alexwrite
+  image_url: https://github.com/alexwrite.png

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-01-31-clientxcms-documentation-multilingual.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-01-31-clientxcms-documentation-multilingual.md
@@ -1,0 +1,55 @@
+---
+title: La documentation CLIENTXCMS est maintenant disponible en français et en anglais
+url: /blog/2026-01-31-clientxcms-documentation-multilingual
+authors: [martindev, alexandre]
+tags: [documentation, update, internationalization, accessibility, ai-workflow]
+---
+
+Bonjour à tous,
+Nous sommes heureux de vous annoncer que la **documentation CLIENTXCMS est désormais entièrement disponible en français et en anglais**.
+
+Cette mise à jour s'inscrit dans un effort plus large d'internationalisation du projet, avec **l'anglais comme langue principale** afin d'encourager les contributions de la communauté mondiale.
+
+{/* TODO: add header image at /img/blog/clientxcms-documentation-multilingual/header.png */}
+
+<!-- truncate -->
+
+## L'internationalisation en priorité
+
+Nous faisons de l'internationalisation une priorité pour CLIENTXCMS. En adoptant l'anglais comme langue principale pour le code et la documentation, nous visons à :
+
+- Réduire les barrières pour les contributeurs internationaux
+- Faciliter la collaboration entre différentes régions
+- Construire une communauté plus forte et plus diverse autour du projet
+
+Toutes les pages de documentation ont été entièrement traduites pour garantir une expérience cohérente dans les deux langues. Vous pouvez basculer entre elles grâce au **sélecteur de langue en haut de la documentation**.
+
+## Vers l'accessibilité AA
+
+Nous travaillons progressivement pour atteindre les **standards d'accessibilité WCAG 2.1 AA**. Le CMS bénéficiera de plusieurs mises à jour majeures axées sur :
+
+- La réduction du nombre de clics nécessaires pour effectuer des actions
+- Une interface plus intuitive
+- L'amélioration de l'utilisabilité globale pour tous les utilisateurs
+
+L'accessibilité n'est pas qu'une case à cocher -- c'est rendre le produit utilisable par tous.
+
+## Workflows assistés par l'IA
+
+Pour faire face à la réalité du temps limité et du nombre restreint de contributeurs, nous avons commencé à intégrer des **workflows assistés par l'IA** dans notre processus de développement.
+
+Pour cette mise à jour de la documentation, l'intégralité de la traduction a été réalisée en **moins de 30 minutes** avec Claude Code Web. Ce type d'efficacité nous permet de concentrer notre énergie là où c'est le plus important.
+
+Nous avons également forké et adapté [BMAD](https://github.com/bmadcode/BMAD-METHOD) à nos besoins. Toutes les sources sont disponibles, et nous encourageons chaque contributeur à utiliser le workflow que nous avons mis en place -- y compris le dossier `bmad` et les commandes Claude. Nous ne proposerons pas d'autres agents que Claude dans nos workflows, au vu de ses parts de marché et de son efficacité pour nos besoins.
+
+## Pourquoi c'est important
+
+Fournir une documentation multilingue permet :
+
+- Une meilleure accessibilité pour les utilisateurs internationaux
+- Une intégration plus facile pour les nouvelles équipes
+- Une meilleure compréhension des fonctionnalités et des workflows
+
+N'oubliez pas que nous vous encourageons tous et toutes à apporter votre contribution au projet, même petite soit-elle !
+
+Nous espérons que cette mise à jour améliorera votre expérience avec CLIENTXCMS, et comme toujours, vos retours sont les bienvenus !


### PR DESCRIPTION
## Summary

Blog post announcing the full FR/EN documentation availability.

- New blog article (EN + FR) covering: internationalization strategy, AA accessibility roadmap, AI-powered workflows with Claude
- Add `alexandre` to `blog/authors.yml`
- Header image placeholder (to be added separately)